### PR TITLE
1.15.2 compute only in fov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ classes
 *.iws
 *.ipr
 out
+bin
+.classpath
+.project
+.settings/org.eclipse.buildship.core.prefs

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 name=bbor
 buildVersion=1.0.14
 # leave a space to reduce merge conflicts on version change
-mcVersion=1.15.1
+mcVersion=1.15.2

--- a/src/main/java/com/irtimaled/bbor/client/Player.java
+++ b/src/main/java/com/irtimaled/bbor/client/Player.java
@@ -8,12 +8,16 @@ public class Player {
     private static double x;
     private static double y;
     private static double z;
+    private static float yaw;
+    private static float pitch;
     private static int dimensionId;
 
     public static void setPosition(double partialTicks, ClientPlayerEntity player) {
         x = player.lastTickPosX + (player.func_226277_ct_() - player.lastTickPosX) * partialTicks;
         y = player.lastTickPosY + (player.func_226278_cu_() - player.lastTickPosY) * partialTicks;
         z = player.lastTickPosZ + (player.func_226281_cx_() - player.lastTickPosZ) * partialTicks;
+        yaw =  player.rotationYaw % 360;
+        pitch = player.rotationPitch;
         dimensionId = player.dimension.getId();
     }
 
@@ -39,5 +43,13 @@ public class Player {
 
     public static Point getPoint() {
         return new Point(x, y, z);
+    }
+    
+    public static float getYaw() {
+        return yaw;
+    }
+    
+    public static float getPitch() {
+        return pitch;
     }
 }

--- a/src/main/java/com/irtimaled/bbor/client/renderers/SpawningSphereRenderer.java
+++ b/src/main/java/com/irtimaled/bbor/client/renderers/SpawningSphereRenderer.java
@@ -6,6 +6,8 @@ import com.irtimaled.bbor.common.MathHelper;
 import com.irtimaled.bbor.common.models.BoundingBoxSpawningSphere;
 import com.irtimaled.bbor.config.ConfigManager;
 
+import net.minecraft.client.Minecraft;
+
 import java.awt.*;
 
 public class SpawningSphereRenderer extends AbstractRenderer<BoundingBoxSpawningSphere> {
@@ -32,10 +34,20 @@ public class SpawningSphereRenderer extends AbstractRenderer<BoundingBoxSpawning
 
     private void renderSpawnableSpaces(OffsetPoint center) {
         Integer renderDistance = ConfigManager.afkSpawnableBlocksRenderDistance.get();
-        int width = MathHelper.floor(Math.pow(2, 2 + renderDistance));
-        int height = MathHelper.floor(Math.pow(2, renderDistance));
+        int width = MathHelper.floor(Math.pow(2, 2 + renderDistance) * 3);
+        int height = MathHelper.floor(Math.pow(2, renderDistance) * 3);
+        
+        // System.out.println(String.format("Rotation: %1f %2f @ %3f", Player.getYaw(), Player.getPitch(), Minecraft.getInstance().gameSettings.fov * 0.6));
+        
+        // long timeStartNormal = java.lang.System.currentTimeMillis();
+        // SpawningSphereHelper.findSpawnableSpaces(center.getPoint(), Player.getCoords(), width, height, (x, y, z) -> true);
+        // System.out.println(String.format("Normal render in : %1d ms", Math.round(java.lang.System.currentTimeMillis() - timeStartNormal)));
 
-        SpawningSphereHelper.findSpawnableSpaces(center.getPoint(), Player.getCoords(), width, height,
+        // long timeStartFov = java.lang.System.currentTimeMillis();
+        // SpawningSphereHelper.findSpawnableSpacesWithFov(center.getPoint(), Player.getCoords(), width, height, Player.getYaw(), Player.getPitch(), Minecraft.getInstance().gameSettings.fov, (x, y, z) -> true);
+        // System.out.println(String.format("Fov render in : %1d ms", Math.round(java.lang.System.currentTimeMillis() - timeStartFov)));
+        
+        SpawningSphereHelper.findSpawnableSpacesWithFov(center.getPoint(), Player.getCoords(), width, height, Player.getYaw(), Player.getPitch(), Minecraft.getInstance().gameSettings.fov,
                 (x, y, z) -> {
                     OffsetBox offsetBox = new OffsetBox(x, y, z, x + 1, y, z + 1);
                     renderCuboid(offsetBox, Color.RED);


### PR DESCRIPTION
Just to show you how I did it.
Mostly for having the required information needed to do a proper cone calculation if wanted.

I would suggest making it an option you can change in game in case the player want to check spawnable spaces by looking down/up instead of looking sideway.

I also left the commented code to compare the performances, but don't expect many fps in case you use that.