### PR TITLE
Fix alwaysVisible to re-enable depth test

### DIFF
--- a/src/main/java/com/irtimaled/bbor/client/renderers/RenderHelper.java
+++ b/src/main/java/com/irtimaled/bbor/client/renderers/RenderHelper.java
@@ -20,11 +20,12 @@ public class RenderHelper {
         enableDepthTest();
 
         if (ConfigManager.alwaysVisible.get()) {
-            GlStateManager.clear(GL11.GL_DEPTH_BUFFER_BIT, Minecraft.IS_RUNNING_ON_MAC);
+            disableDepthTest();
         }
     }
 
     public static void afterRender() {
+        enableDepthTest();
         polygonModeFill();
         GlStateManager.enableCull();
         enableTexture();


### PR DESCRIPTION
When enabling 'alwaysVisible' in the config, transparent blocks would also show through other blocks.  I noticed this with clouds, glass, and water that was touching air.  This change seems to fix that for me on Windows, but I don't know why the clearing of the depth buffer bit was used and why IS_SYSTEM_MAC is checked.  Possibly this could be wrapped in an If for IS_SYSTEM_MAC instead and the old way used for macs if that is important.